### PR TITLE
Enviroment variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The configuration is an object that looks like this:
       "execute": false, // Write the last command without executing it
       "shellPath": '/bin/bash', // Path to a custom shell executable
       "shellArgs": ["--foo"] // Arguments to pass to the shell executable
+      "env": {"name": "value", "name2": "value2"}, // Key value pairs for enviroment variables
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The configuration is an object that looks like this:
 {
   "autorun": true, // Execute `Terminals: Run` automatically at startup or when the project is added to the workspace
   "autokill": true, // Kill all the terminals created from this configuration when the project is removed from the workspace
+  "env": { "name": "value" }, // Key value pairs of enviroment variables that will be applied to any terminal opened
   "terminals": [ // Array of terminals to open
     { // An object describing a terminal, most entries are optional
       "name": "My Terminal", // The name of the terminal, it will be displayed in the dropdown
@@ -78,6 +79,7 @@ The configuration is an object that looks like this:
       "shellPath": '/bin/bash', // Path to a custom shell executable
       "shellArgs": ["--foo"] // Arguments to pass to the shell executable
       "env": {"name": "value", "name2": "value2"}, // Key value pairs for enviroment variables
+      "applyGobalEnv": false, // Don't set enviroment variables that where set on the top level
     }
   ]
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -55,7 +55,7 @@ onRootRemove ();
 
 async function run ( terminal, config?, substitutions? ) {
 
-  const {name, target, command, commands, execute, recycle, substitution, shellPath, shellArgs} = terminal,
+  const {name, target, command, commands, execute, recycle, substitution, shellPath, shellArgs, env } = terminal,
         configPath = _.get ( config, 'configPath' ) as string;
 
   let texts = commands || [];
@@ -75,7 +75,7 @@ async function run ( terminal, config?, substitutions? ) {
   const cacheTarget = target || name,
         cacheTerm = recycle !== false && cache[cacheTarget],
         isCached = !!cacheTerm,
-        term = cacheTerm || vscode.window.createTerminal ( cacheTarget, shellPath, shellArgs );
+        term = cacheTerm || vscode.window.createTerminal ( { env, name: cacheTarget, shellPath, shellArgs } );
 
   cache[cacheTarget] = term;
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -55,8 +55,9 @@ onRootRemove ();
 
 async function run ( terminal, config?, substitutions? ) {
 
-  const {name, target, command, commands, execute, recycle, substitution, shellPath, shellArgs, env } = terminal,
-        configPath = _.get ( config, 'configPath' ) as string;
+  const { name, target, command, commands, execute, recycle, substitution, shellPath, shellArgs, env: terminalEnv, applyGlobalEnv } = terminal,
+    configPath = _.get(config, 'configPath') as string,
+    configEnv = _.get(config, 'env') as { [key: string]: string };
 
   let texts = commands || [];
 
@@ -70,6 +71,11 @@ async function run ( terminal, config?, substitutions? ) {
 
     texts = texts.map ( text => Substitutions.apply ( text, substitutions ) );
 
+  }
+
+  let env = terminalEnv;
+  if (applyGlobalEnv) {
+    env = _.extend(env, configEnv);
   }
 
   const cacheTarget = target || name,


### PR DESCRIPTION
Can set environment variables to be applied to a specific terminal, or globally to any terminal opened through the extension
fixes #10 