### PR TITLE
Wait for the startup to finish before initializing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
Solves an issue where environment variables being changed (by other extensions) after the terminal initialization would immediately prompt for reloading the newly created terminals