### PR TITLE
Update icon library link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,7 +150,7 @@ This extension supports some special tokens that you can put in your configurati
 
 - **[Commands](https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-commands)**: Use this other extension, the `terminals.runTerminalByName` command and, optionally, the `onlyAPI` configuration option to create terminals that can be run with a click from the statusbar.
 - **Self-destroying terminals**: it's a common use case to run some commands and then close the terminal, to do this simply put an `exit 0` command at the end of your commands list.
-- **Icons**: [here](https://octicons.github.com/) you can browse a list of supported icons. If for instance you click the first icon, you'll get a page with `.octicon-alert` written in it, to get the string to use simply remove the `.octicon-` part, so in this case the icon name would be `alert`.
+- **Icons**: [here](https://microsoft.github.io/vscode-codicons/dist/codicon.html) you can browse a list of supported icons.
 
 ## Contributing
 


### PR DESCRIPTION
When using the icons link from the README file, I noticed most icons didn't actually work like it should. When reviewing how the [icons are fetched](https://github.com/maxijonson/vscode-terminals/blob/2e2f66e0c16379f133e490a8c85d6e4d5197f466/src/run.ts#L113-L114), I noticed they were using `vscode.ThemeIcon`, which is actually from [codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html) ([source](https://code.visualstudio.com/api/references/icons-in-labels)), not octicons.